### PR TITLE
Deceased Mentions and More

### DIFF
--- a/transplant_llm/pydantic_study_variables.py
+++ b/transplant_llm/pydantic_study_variables.py
@@ -299,7 +299,7 @@ class CancerMention(SpanAugmentedMention):
 class DeceasedMention(SpanAugmentedMention):
     deceased: bool | None = Field(
         None, 
-        description='In the present encounter, does the note state if the patient is deceased?'
+        description='Does the note indicate that the patient is deceased?'
     )
     deceased_datetime: str | None = Field(
         None, 


### PR DESCRIPTION
Introduces the DeceasedMention (partially addressing #3) and a few other notable changes: 
- A more consistent naming schema, something I'm thinking about more often as we start to think about constructing  these models using a UI tool/auto-generating the labelstudio UI + parsing logic based on the structure of these Mentions. 
    - I know there's a modest concern about possible impacts to performance. We can examine that empirically in future experiments and reconsider this change if needed.
- `KidneyTransplantMentionLabels(StrEnum)` is now fixed (it wasn't actually defining any Enum members before because we were using `:` instead of `=`. 