### PR TITLE
Adds a minimum length to the annotations generated for medications

### DIFF
--- a/kidney_transplant_llm/medication/annotation.py
+++ b/kidney_transplant_llm/medication/annotation.py
@@ -153,9 +153,9 @@ class RxClassImmunosuppressionMention(RxClassMention):
 ##########################################################
 
 class MedicationAnnotation(BaseModel):
-    rx_class_anti_infective: List[RxClassAntiInfectiveMention]
-    rx_class_cancer: List[RxClassCancerMention]
-    rx_class_kidney: List[RxClassKidneyMention]
-    rx_class_immunosuppression: List[RxClassImmunosuppressionMention]
+    rx_class_anti_infective: List[RxClassAntiInfectiveMention] = Field(..., min_length=1)
+    rx_class_cancer: List[RxClassCancerMention] = Field(..., min_length=1)
+    rx_class_kidney: List[RxClassKidneyMention] = Field(..., min_length=1)
+    rx_class_immunosuppression: List[RxClassImmunosuppressionMention] = Field(..., min_length=1)
 
 

--- a/kidney_transplant_llm/pydantic_study_variables.py
+++ b/kidney_transplant_llm/pydantic_study_variables.py
@@ -400,7 +400,7 @@ kidney_transplant_mention_groups_metadata = {
 # Tying the Label Enum to the Group Enum and other metadata (display strings, e.g.)
 kidney_transplant_mention_ls_metadata = {
     KidneyTransplantMentionLabels.donor_transplant_date_mention : {
-        "display": "Transplate Date",
+        "display": "Transplant Date",
         "group": KidneyTransplantMentionGroups.TRANSPLANT_DATE,
         "hotkey": "W",
         "hotkey_mnemonic": "Which day?",


### PR DESCRIPTION
Additionally fixes a typo with transplant dates display labels. 
The minimum length helps avoid parsing quirks downstream turning these observations into labelstudio predictions. 