### PR TITLE
Add JSON-schema-file generation code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,8 @@ venv/
 data/
 
 __pycache__/
-*.pyc   
+*.pyc
+
+/kidney_transplant_llm/donor.json
+/kidney_transplant_llm/history.json
+/kidney_transplant_llm/longitudinal.json

--- a/kidney_transplant_llm/pydantic_study_variables.py
+++ b/kidney_transplant_llm/pydantic_study_variables.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 from enum import StrEnum, auto
 from pydantic import BaseModel, Field
 
@@ -899,3 +902,16 @@ kidney_transplant_mention_ls_metadata = {
         "hotkey_mnemonic": "(X) marks deceased",
     },
 }
+
+
+if __name__ == "__main__":
+    basedir = os.path.dirname(__file__)
+
+    with open(f"{basedir}/donor.json", "w", encoding="utf8") as f:
+        json.dump(KidneyTransplantDonorGroupAnnotation.model_json_schema(), f, indent=2)
+
+    with open(f"{basedir}/history.json", "w", encoding="utf8") as f:
+        json.dump(MultipleTransplantHistoryAnnotation.model_json_schema(), f, indent=2)
+
+    with open(f"{basedir}/longitudinal.json", "w", encoding="utf8") as f:
+        json.dump(KidneyTransplantLongitudinalAnnotation.model_json_schema(), f, indent=2)


### PR DESCRIPTION
This will be used to generate the files that the ETL needs for its NLP flow. This way, we only need the pydantic models here, not in the ETL any longer.